### PR TITLE
added flask_cors to requirements.txt for CORS support in python API

### DIFF
--- a/python_api/requirements.txt
+++ b/python_api/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 pybind11
 setuptools
+Flask-Cors


### PR DESCRIPTION
**Problem:** app.py requires flask_cors for CORS (essential for JS dashboard), but it's missing from requirements.txt, causing ModuleNotFoundError.
**Fix:** Add Flask-Cors to requirements.txt.