### PR TITLE
fix: fPIC linker error References issue #47

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.30)
-
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 project(QuantRiskEngine LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
This PR fixes the relocation error by ensuring static libraries are compiled with -fPIC as indicated in issue #47.
